### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+At VIVIA CONNECT, security is a top priority. If you believe you’ve discovered a potential vulnerability in our application, integrations (e.g., Stripe, Zillow API, Realtor syndication), or infrastructure, we encourage responsible disclosure.
+
+Please report security issues directly to our security team:
+
+📧 **Email**: security@viviarentals.com  
+🔐 **PGP Key** (optional): [https://viviarentals.com/security-pgp](https://viviarentals.com/security-pgp)
+
+We will acknowledge your report within 2 business days and aim to provide a resolution timeline based on the severity of the issue.
+
+---
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| `main` (production) | ✅ Yes |
+| `dev` (testing/staging) | ✅ Yes |
+| Any deprecated branches | ❌ No |
+
+---
+
+## Scope
+
+This policy applies to:
+
+- [viviarentals.com](https://viviarentals.com)
+- Stripe integrations (Elements, Checkout, Connect)
+- Google Cloud deployed functions
+- Webhooks (e.g., `/stripe_webhooks`, `/zillow_webhooks`, `/realtor_webhooks`)
+- Admin tools and dashboards
+
+---
+
+## Exclusions
+
+Please avoid automated scans or denial-of-service attacks. These are outside the scope of responsible disclosure.
+
+---
+
+Thank you for helping us keep VIVIA CONNECT safe and secure for everyone.


### PR DESCRIPTION
6:52:12 PM: Waiting for other deploys from your team to complete. Check the queue: https://app.netlify.com/teams/viviarentals/builds
6:52:50 PM: Build ready to start
6:53:20 PM: build-image version: eaaf26532258c7e103a0d73173f1190b61d98750 (noble)
6:53:20 PM: buildbot version: 0768c4bcd49b4f313099cd17ac3355c0653a94ea
6:53:20 PM: Fetching cached dependencies
6:53:20 PM: Failed to fetch cache, continuing with build
6:53:20 PM: Starting to prepare the repo for build
6:53:21 PM: No cached dependencies found. Cloning fresh repo
6:53:21 PM: git clone --filter=blob:none git@github.com:viviarentals/viviarentals.netlify.app
6:53:21 PM: Preparing Git Reference pull/1/head
6:53:23 PM: Starting to install dependencies
6:53:23 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:23 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:23 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:23 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:23 PM: You can disable idiomatic version files with:
6:53:23 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:23 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:23 PM: Python version set to 3.13.3
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: Ruby version set to 3.4.3
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: Go version set to 1.24.3
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: Using PHP version 8.3
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:24 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:24 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:24 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:24 PM: You can disable idiomatic version files with:
6:53:24 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:24 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:25 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:25 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:25 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:25 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:25 PM: You can disable idiomatic version files with:
6:53:25 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:25 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:25 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:25 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:25 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:25 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:25 PM: You can disable idiomatic version files with:
6:53:25 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:25 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:25 PM: Attempting Node.js version 'v18' from .nvmrc
6:53:25 PM: Downloading and installing node v18.20.8...
6:53:25 PM: Downloading https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.xz...
6:53:26 PM: Computing checksum with sha256sum
6:53:26 PM: Checksums matched!
6:53:27 PM: Now using node v18.20.8 (npm v10.8.2)
6:53:27 PM: Enabling Node.js Corepack
6:53:27 PM: Started restoring cached build plugins
6:53:27 PM: Finished restoring cached build plugins
6:53:27 PM: Started restoring cached corepack dependencies
6:53:27 PM: Finished restoring cached corepack dependencies
6:53:27 PM: No npm workspaces detected
6:53:27 PM: Started restoring cached node modules
6:53:27 PM: Finished restoring cached node modules
6:53:28 PM: Installing npm packages using npm version 10.8.2
6:53:29 PM: npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
6:53:29 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
6:53:29 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
6:53:29 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
6:53:29 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
6:53:29 PM: npm warn deprecated string-similarity@1.2.2: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
6:53:29 PM: npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
6:53:30 PM: npm warn deprecated google-p12-pem@3.1.4: Package is no longer maintained
6:53:41 PM: added 682 packages in 13s
6:53:41 PM: npm packages installed
6:53:41 PM: Successfully installed dependencies
6:53:41 PM: Starting build script
6:53:41 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:41 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:41 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:41 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:41 PM: You can disable idiomatic version files with:
6:53:41 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:41 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:41 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:41 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:41 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:41 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:41 PM: You can disable idiomatic version files with:
6:53:41 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:41 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:41 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:41 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:41 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:41 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:41 PM: You can disable idiomatic version files with:
6:53:41 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:41 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:42 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:42 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:42 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:42 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:42 PM: You can disable idiomatic version files with:
6:53:42 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:42 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:42 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:42 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:42 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:42 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:42 PM: You can disable idiomatic version files with:
6:53:42 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:42 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:42 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:42 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:42 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:42 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:42 PM: You can disable idiomatic version files with:
6:53:42 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:42 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:42 PM: Detected 1 framework(s)
6:53:42 PM: "next" at version "15.3.2"
6:53:42 PM: Section completed: initializing
6:53:43 PM: ​
6:53:43 PM: Netlify Build                                                 
6:53:43 PM: ────────────────────────────────────────────────────────────────
6:53:43 PM: ​
6:53:43 PM: ❯ Version
6:53:43 PM:   @netlify/build 33.1.3
6:53:43 PM: ​
6:53:43 PM: ❯ Flags
6:53:43 PM:   accountId: 67fbb3d59f81bd17346cd2b5
6:53:43 PM:   baseRelDir: true
6:53:43 PM:   buildId: 682e834c044d460008b698ab
6:53:43 PM:   deployId: 682e834c044d460008b698ad
6:53:43 PM: ​
6:53:43 PM: ❯ Current directory
6:53:43 PM:   /opt/build/repo
6:53:43 PM: ​
6:53:43 PM: ❯ Config file
6:53:43 PM:   /opt/build/repo/netlify.toml
6:53:43 PM: ​
6:53:43 PM: ❯ Context
6:53:43 PM:   deploy-preview
6:53:45 PM: ​
6:53:45 PM: ❯ Installing extensions
6:53:45 PM:    - user-agent-blocker
6:53:45 PM:    - async-workloads
6:54:34 PM: ​
6:54:34 PM: ❯ Using Next.js Runtime - v5.11.2
6:54:34 PM: ​
6:54:34 PM: ❯ Loading extensions
6:54:34 PM:    - user-agent-blocker
6:54:34 PM:    - async-workloads
6:54:35 PM: No Next.js cache to restore
6:54:35 PM: ​
6:54:35 PM: build.command from netlify.toml                               
6:54:35 PM: ────────────────────────────────────────────────────────────────
6:54:35 PM: ​
6:54:35 PM: $ npm run build
6:54:35 PM: > content-ops-starter@0.1.0 build
6:54:35 PM: > next build
6:54:36 PM: ⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
6:54:36 PM:    ▲ Next.js 15.3.2
6:54:36 PM:    Linting and checking validity of types ...
6:54:39 PM:    Creating an optimized production build ...
6:54:49 PM:  ✓ Compiled successfully in 6.0s
6:54:49 PM:    Collecting page data ...
6:54:50 PM:    Generating static pages (0/17) ...
6:54:51 PM:    Generating static pages (4/17)
6:54:51 PM:    Generating static pages (8/17)
6:54:51 PM:    Generating static pages (12/17)
6:54:51 PM:  ✓ Generating static pages (17/17)
6:54:56 PM:    Finalizing page optimization ...
6:54:56 PM:    Collecting build traces ...
6:55:01 PM: Route (pages)                                                        Size  First Load JS    
6:55:01 PM: ┌   /_app                                                             0 B        94.6 kB
6:55:01 PM: ├ ● /[[...slug]] (3844 ms)                                        3.12 kB        97.7 kB
6:55:01 PM: ├   ├ /blog/what-is-a-design-system (445 ms)
6:55:01 PM: ├   ├ /pricing (371 ms)
6:55:01 PM: ├   ├ / (370 ms)
6:55:01 PM: ├   ├ /careers (369 ms)
6:55:01 PM: ├   ├ /blog/track-the-right-analytics-for-your-business (369 ms)
6:55:01 PM: ├   ├ /blog/top-twenty-ways-to-save-time (369 ms)
6:55:01 PM: ├   ├ /blog/top-ten-lessons-we-learned (369 ms)
6:55:01 PM: ├   └ [+8 more paths]
6:55:01 PM: ├ ○ /404                                                            190 B        94.8 kB
6:55:01 PM: └ ƒ /api/reindex                                                      0 B        94.6 kB
6:55:01 PM: + First Load JS shared by all                                      106 kB
6:55:01 PM:   ├ chunks/framework-2f335d22a7318891.js                          57.7 kB
6:55:01 PM:   ├ chunks/main-6d9798f98242e321.js                                 34 kB
6:55:01 PM:   ├ css/dcf93de0ec4fe6d2.css                                      11.8 kB
6:55:01 PM:   └ other shared chunks (total)                                   2.89 kB
6:55:01 PM: ○  (Static)   prerendered as static content
6:55:01 PM: ●  (SSG)      prerendered as static HTML (uses getStaticProps)
6:55:01 PM: ƒ  (Dynamic)  server-rendered on demand
6:55:01 PM: ​
6:55:01 PM: (build.command completed in 25.9s)
6:55:01 PM: Next.js cache saved
6:55:01 PM: Next.js cache saved
6:55:03 PM: Async Workloads will not run because there is no AWL_API_KEY env var set.
6:55:03 PM: ​
6:55:03 PM: Functions bundling                                            
6:55:03 PM: ────────────────────────────────────────────────────────────────
6:55:03 PM: ​
6:55:03 PM: Packaging Functions from .netlify/functions-internal directory:
6:55:03 PM:  - ___netlify-server-handler/___netlify-server-handler.mjs
6:55:03 PM: ​
6:55:05 PM: ​
6:55:05 PM: (Functions bundling completed in 2s)
6:55:06 PM: ​
6:55:06 PM: Deploy site                                                   
6:55:06 PM: ────────────────────────────────────────────────────────────────
6:55:06 PM: ​
6:55:06 PM: Starting to deploy site from '.next'
6:55:06 PM: Calculating files to upload
6:55:06 PM: 0 new file(s) to upload
6:55:06 PM: 1 new function(s) to upload
6:55:14 PM: Post processing - redirect rules
6:55:14 PM: Post processing done
6:55:14 PM: Section completed: postprocessing
6:55:14 PM: Starting post processing
6:55:14 PM: Skipping form detection
6:55:14 PM: Post processing - header rules
6:55:14 PM: Section completed: deploying
6:55:15 PM: Site is live ✨
6:55:16 PM: Finished waiting for live deploy in 2.191s
6:55:16 PM: Site deploy was successfully initiated
6:55:16 PM: ​
6:55:16 PM: (Deploy site completed in 9.9s)
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unpipe listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: (Use `node --trace-warnings ...` to show where the warning was created)
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 finish listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unpipe listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: (node:3256) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 finish listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:55:19 PM: ​
6:55:19 PM: Netlify Build Complete                                        
6:55:19 PM: ────────────────────────────────────────────────────────────────
6:55:19 PM: ​
6:55:19 PM: (Netlify Build completed in 1m 36s)
6:55:20 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:55:20 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:55:20 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools node
6:55:20 PM: You can disable idiomatic version files with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:55:20 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:55:20 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:55:20 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:55:20 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools node
6:55:20 PM: You can disable idiomatic version files with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:55:20 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:55:20 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:55:20 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:55:20 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools node
6:55:20 PM: You can disable idiomatic version files with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:55:20 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:55:20 PM: Caching artifacts
6:55:20 PM: Started saving node modules
6:55:20 PM: Finished saving node modules
6:55:20 PM: Started saving build plugins
6:55:20 PM: Finished saving build plugins
6:55:20 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:55:20 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:55:20 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools node
6:55:20 PM: You can disable idiomatic version files with:
6:55:20 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:55:20 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:55:20 PM: Started saving go cache
6:55:21 PM: Finished saving go cache
6:55:21 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:55:21 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:55:21 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:55:21 PM:     mise settings add idiomatic_version_file_enable_tools node
6:55:21 PM: You can disable idiomatic version files with:
6:55:21 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:55:21 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:55:21 PM: Started saving python cache
6:55:21 PM: Finished saving python cache
6:55:21 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:55:21 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:55:21 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:55:21 PM:     mise settings add idiomatic_version_file_enable_tools node
6:55:21 PM: You can disable idiomatic version files with:
6:55:21 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:55:21 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:55:21 PM: Started saving ruby cache
6:55:22 PM: Finished saving ruby cache
6:55:22 PM: Started saving corepack cache
6:55:22 PM: Finished saving corepack cache
6:55:22 PM: Started saving emacs cask dependencies
6:55:22 PM: Finished saving emacs cask dependencies
6:55:22 PM: Started saving maven dependencies
6:55:22 PM: Finished saving maven dependencies
6:55:22 PM: Started saving boot dependencies
6:55:22 PM: Finished saving boot dependencies
6:55:22 PM: Started saving rust rustup cache
6:55:22 PM: Finished saving rust rustup cache
6:55:22 PM: Build script success
6:55:22 PM: Section completed: building
6:55:42 PM: Uploading Cache of size 431.7MB
6:55:43 PM: Section completed: cleanup
6:55:43 PM: Finished processing build request in 2m23.423s